### PR TITLE
ci: enable Rust source checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt
+          components: clippy, rustfmt
 
       - name: Install additional build dependencies
         run: |
@@ -29,6 +29,12 @@ jobs:
         with:
           command: fmt
           args: --check
+
+      - name: Lint code
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- --deny warnings
 
       - name: Build binary
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
 
       - name: Install additional build dependencies
         run: |
@@ -22,6 +23,12 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config
 
           sudo snap install protobuf --classic
+
+      - name: Check code format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
 
       - name: Build binary
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.69.0
           components: clippy, rustfmt
 
       - name: Install additional build dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ratings"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.69.0"
 
 [dependencies]
 dotenv = "0.15.0"


### PR DESCRIPTION
This PR adds formatting and linting on pull requests and also pins the minimum supported Rust version.

The CI `toolchain` version has been changed from `stable` to match this, allowing new lint checks to be handled deliberately rather than polluting unrelated future PRs.
