### PR TITLE
build(charm): fix charm build error due to missing dependency

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -1,2 +1,2 @@
 ops == 2.2.0
-psycopg[binary] == 3.1.9
+psycopg[binary] == 3.1.10


### PR DESCRIPTION
There seems to have been some weirdness with the release of `psycopg` since I wrote the PR and it now fails to build. This PR fixes the charm build error and should make the CI green again.