### PR TITLE
feat: remove get_ prefix from getters

### DIFF
--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -25,7 +25,7 @@ pub async fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         .add_service(build_reflection_service());
     let server = build_servers(server);
 
-    let socket: SocketAddr = config.get_socket().parse()?;
+    let socket: SocketAddr = config.socket().parse()?;
     info!("Binding to {socket}");
     server.serve(socket).await?;
 

--- a/src/features/user/infrastructure.rs
+++ b/src/features/user/infrastructure.rs
@@ -7,7 +7,7 @@ use super::entities::{User, Vote};
 pub(crate) async fn create_user_in_db(app_ctx: &AppContext, user: User) -> Result<User, UserError> {
     let mut pool = app_ctx
         .infrastructure()
-        .get_repository()
+        .repository()
         .await
         .map_err(|error| {
             error!("{error:?}");
@@ -45,7 +45,7 @@ pub(crate) async fn create_user_in_db(app_ctx: &AppContext, user: User) -> Resul
 pub(crate) async fn user_seen(app_ctx: &AppContext, client_hash: &str) -> Result<bool, UserError> {
     let mut pool = app_ctx
         .infrastructure()
-        .get_repository()
+        .repository()
         .await
         .map_err(|error| {
             error!("{error:?}");
@@ -76,7 +76,7 @@ pub(crate) async fn delete_user_by_client_hash(
 ) -> Result<u64, UserError> {
     let mut pool = app_ctx
         .infrastructure()
-        .get_repository()
+        .repository()
         .await
         .map_err(|error| {
             error!("{error:?}");
@@ -103,7 +103,7 @@ pub(crate) async fn delete_user_by_client_hash(
 pub(crate) async fn save_vote_to_db(app_ctx: &AppContext, vote: Vote) -> Result<u64, UserError> {
     let mut pool = app_ctx
         .infrastructure()
-        .get_repository()
+        .repository()
         .await
         .map_err(|error| {
             error!("{error:?}");
@@ -139,7 +139,7 @@ pub(crate) async fn find_user_votes(
 ) -> Result<Vec<Vote>, UserError> {
     let mut pool = app_ctx
         .infrastructure()
-        .get_repository()
+        .repository()
         .await
         .map_err(|error| {
             error!("{error:?}");

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -18,7 +18,7 @@ impl Config {
         envy::prefixed("APP_").from_env::<Config>()
     }
 
-    pub fn get_socket(&self) -> String {
+    pub fn socket(&self) -> String {
         let Config { port, host, .. } = self;
         format!("{host}:{port}")
     }

--- a/src/utils/infrastructure.rs
+++ b/src/utils/infrastructure.rs
@@ -28,7 +28,7 @@ impl Infrastructure {
         Ok(Infrastructure { postgres, jwt })
     }
 
-    pub async fn get_repository(&self) -> Result<PoolConnection<Postgres>, sqlx::Error> {
+    pub async fn repository(&self) -> Result<PoolConnection<Postgres>, sqlx::Error> {
         self.postgres.acquire().await
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -2,5 +2,4 @@ pub mod assert;
 pub mod client_user;
 pub mod data_faker;
 pub mod hooks;
-pub mod repo_user;
 pub mod with_lifecycle;

--- a/tests/helpers/repo_user.rs
+++ b/tests/helpers/repo_user.rs
@@ -1,6 +1,0 @@
-use ratings::features::user::entities::User;
-
-#[allow(dead_code)]
-pub async fn get_user(_id: &str) -> Option<User> {
-    todo!()
-}

--- a/tests/user_reject_invalid_register_test.rs
+++ b/tests/user_reject_invalid_register_test.rs
@@ -12,7 +12,7 @@ async fn blank() -> Result<(), Box<dyn std::error::Error>> {
 
     with_lifecycle(async {
         let id = "";
-        let client = UserClient::new(&config.get_socket());
+        let client = UserClient::new(&config.socket());
 
         match client.register(id).await {
             Ok(response) => panic!("expected Err but got Ok: {response:?}"),
@@ -31,7 +31,7 @@ async fn wrong_length() -> Result<(), Box<dyn std::error::Error>> {
 
     with_lifecycle(async {
         let client_hash = "foobarbazbun";
-        let client = UserClient::new(&config.get_socket());
+        let client = UserClient::new(&config.socket());
 
         match client.register(client_hash).await {
             Ok(response) => panic!("expected Err but got Ok: {response:?}"),

--- a/tests/user_simple_lifecycle_test.rs
+++ b/tests/user_simple_lifecycle_test.rs
@@ -22,11 +22,11 @@ struct TestData {
 
 impl TestData {
     async fn repository(&self) -> Result<PoolConnection<Postgres>, sqlx::Error> {
-        self.app_ctx.clone().infrastructure().get_repository().await
+        self.app_ctx.clone().infrastructure().repository().await
     }
 
     fn socket(&self) -> String {
-        self.app_ctx.config().get_socket()
+        self.app_ctx.config().socket()
     }
 }
 
@@ -38,7 +38,7 @@ async fn user_simple_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> 
 
     with_lifecycle(async {
         let data = TestData {
-            client: Some(UserClient::new(&config.get_socket())),
+            client: Some(UserClient::new(&config.socket())),
             app_ctx,
             id: None,
             token: None,


### PR DESCRIPTION
The rust convention for no `get_` prefix can be found [here](https://rust-lang.github.io/api-guidelines/naming.html).