### PR TITLE
test(charm): simplify relation tests with new add_relation

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -1,2 +1,2 @@
-ops == 2.2.0
+ops == 2.6.0
 psycopg[binary] == 3.1.10


### PR DESCRIPTION
A new version of the `ops` library released yesterday which introduces a nice simplification in the test harness, meaning you can now add a relation, prime it with a unit, and specify app/unit data all within the same call.

This PR is just a simple refactoring to make the tests a little easier to read.